### PR TITLE
[#2] [Infrastructure] Setup CI with Github Actions for code linting

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+
+env:
+  TERRAFORM_VERSION: "1.3.6"
+
+jobs:
+  linting:
+    name: Lint Terraform files
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Run Terraform format
+        run: terraform fmt -recursive -check
+
+      - name: Run tfsec linter
+        id: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.2


### PR DESCRIPTION
- Close #2

## What happened 👀

`terraform fmt` and `tfsec` linters were set up for the project to be run on each push to the repository.

## Proof Of Work 📹

For the test I added not formated code to the repo, CI was failed:

![image](https://user-images.githubusercontent.com/475367/208790081-4bb2426b-bfd4-4b92-9157-dbe5980c06e5.png)

Otherwise CI is green:

![image](https://user-images.githubusercontent.com/475367/208790142-ce846d68-0031-4e4b-827d-31035318edbf.png)
