### PR TITLE
[#5] [Infrastructure] Setup AWS CloudWatch Logs

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -18,6 +18,12 @@ module "vpc" {
   namespace = local.namespace
 }
 
+module "log" {
+  source = "../modules/cloudwatch"
+
+  namespace = var.app_name
+}
+
 module "security_group" {
   source = "../modules/security_group"
 
@@ -60,6 +66,7 @@ module "ecs" {
   ecr_tag                            = var.ecr_tag
   security_groups                    = module.security_group.ecs_security_group_ids
   alb_target_group_arn               = module.alb.alb_target_group_arn
+  aws_cloudwatch_log_group_name      = module.log.aws_cloudwatch_log_group_name
   deployment_maximum_percent         = var.ecs.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs.deployment_minimum_healthy_percent
   web_container_cpu                  = var.ecs.web_container_cpu

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "awslogs-${var.namespace}-log-group"
+  retention_in_days = var.log_retention_in_days
+}

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,3 +1,4 @@
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "main" {
   name              = "awslogs-${var.namespace}-log-group"
   retention_in_days = var.log_retention_in_days

--- a/modules/cloudwatch/outputs.tf
+++ b/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_cloudwatch_log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.main.name
+}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -1,0 +1,9 @@
+variable "namespace" {
+  description = "The namespace for the CloudWatch"
+  type        = string
+}
+
+variable "log_retention_in_days" {
+  description = "How long (days) to retain the log data"
+  default     = 14
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -28,6 +28,7 @@ locals {
     deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
     aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url
     aws_ecr_tag                        = var.ecr_tag
+    aws_cloudwatch_log_group_name      = var.aws_cloudwatch_log_group_name
 
     environment_variables = local.environment_variables
     secrets_variables     = var.secrets_variables

--- a/modules/ecs/service.json.tftpl
+++ b/modules/ecs/service.json.tftpl
@@ -12,6 +12,14 @@
         "protocol": "tcp"
       }
     ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "${namespace}-service",
+        "awslogs-group": "${aws_cloudwatch_log_group_name}"
+      }
+    },
     "environment": ${jsonencode(environment_variables)},
     "secrets": ${jsonencode(secrets_variables)},
     "ulimits": [

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -71,3 +71,8 @@ variable "secret_arns" {
   description = "The secrets ARNs for Task Definition"
   type        = list(string)
 }
+
+variable "aws_cloudwatch_log_group_name" {
+  description = "AWS CloudWatch Log Group name"
+  type        = string
+}


### PR DESCRIPTION
- Close #5

Set up AWS ALB.

Accessing application logs is an important part of monitoring and troubleshooting the performance of a system. AWS CloudWatch Logs is a service that allows you to collect, monitor, and analyze log data from various sources in the AWS Cloud. 

## Proof Of Work 📹

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
```
