### PR TITLE
[#28] [Chore] Lock Terraform version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.3.7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-Terraform version for the configuration is 1.3.6 (it is used both by CI and Terraform Cloud).
+The version of Terraform being used for the configuration is 1.3.7, and it is utilized by both the CI system and Terraform Cloud.
 
-# DevOps IC Infrastructure
+## About
 
-This repository hosts the Terraform infrastructure project that serves the [DevOps IC app](https://github.com/Nihisil/nimble-devops-ic-app).
+This repository hosts the Terraform infrastructure project that serves the [example app](https://github.com/Nihisil/nimble-devops-ic-app).
+
+## Installation
+
+Terraform can be installed with using `asdf install` command.
+
+Before that you need to install [asdf](https://asdf-vm.com/) with [asdf plugin-add terraform](https://github.com/asdf-community/asdf-hashicorp).
 
 ## Documentation
 

--- a/base/.terraform.lock.hcl
+++ b/base/.terraform.lock.hcl
@@ -2,8 +2,10 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.48.0"
+  version     = "4.48.0"
+  constraints = "~> 4.0"
   hashes = [
+    "h1:Fz26mWZmM9syrY91aPeTdd3hXG4DvMR81ylWC9xE2uA=",
     "h1:t4+ZVZIg8DbyFTMy4sZcvb7FULMG3mpg9Woh/2IaQ+o=",
     "zh:08f5e3c5256a4fbd5c988863d10e5279172b2470fec6d4fb13c372663e7f7cac",
     "zh:2a04376b7fa84681bd2938973c7d0822c8c0f0656a4e7661a2f50ac4d852d4a3",

--- a/base/main.tf
+++ b/base/main.tf
@@ -6,4 +6,6 @@ terraform {
       tags = ["aws-infrastructure"]
     }
   }
+
+  required_version = "1.3.7"
 }

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -6,6 +6,8 @@ terraform {
       name = "devops-ic-shared"
     }
   }
+
+  required_version = "1.3.7"
 }
 
 module "ecr" {


### PR DESCRIPTION
- Close #28 

## What happened 👀

It is a good practice to lock software on specific version to avoid any surprises in the future.

## Proof Of Work 📹

If TF Cloud version doesn't match configuration version, there will be an error:

![image](https://user-images.githubusercontent.com/475367/215933866-d10565d6-a976-407f-9c58-fce8d7814ebd.png)

If correct version is set, the plan is running fine:

![image](https://user-images.githubusercontent.com/475367/215933965-32a10690-5a64-47eb-81e5-1405a0bd30d5.png)

