### PR TITLE
[#4] [Infrastructure] Setup AWS VPC

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -9,3 +9,13 @@ terraform {
 
   required_version = "1.3.7"
 }
+
+locals {
+  namespace = "${var.app_name}-${var.environment}"
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  namespace = local.namespace
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,17 @@
+data "aws_availability_zones" "available" {}
+
+#tfsec:ignore:aws-ec2-no-public-ip-subnet tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.18.1"
+
+  name                   = "${var.namespace}-vpc"
+  cidr                   = var.cidr
+  azs                    = data.aws_availability_zones.available.names
+  private_subnets        = var.private_subnet_cidrs
+  public_subnets         = var.public_subnet_cidrs
+  enable_nat_gateway     = var.enable_nat_gateway
+  single_nat_gateway     = var.single_nat_gateway
+  one_nat_gateway_per_az = var.one_nat_gateway_per_az
+  enable_dns_hostnames   = var.enable_dns_hostnames
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = module.vpc.private_subnets
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "Private subnet CIDR blocks"
+  value       = module.vpc.private_subnets_cidr_blocks
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs"
+  value       = module.vpc.public_subnets
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,45 @@
+variable "namespace" {
+  description = "Namespace for the VPCs, used as the prefix for the VPC names, e.g. acme-web-staging"
+  type        = string
+}
+
+variable "cidr" {
+  description = "VPC CIDR"
+  default     = "10.0.0.0/16"
+}
+
+variable "private_subnet_cidrs" {
+  description = "VPC private subnet CIDRs"
+  type        = list(any)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "VPC public subnet CIDRs"
+  type        = list(any)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  description = "VPC NAT gateway flag"
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "VPC single NAT gateway flag"
+  type        = bool
+  default     = true
+}
+
+variable "one_nat_gateway_per_az" {
+  description = "VPC one NAT gateway per AZ flag"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_hostnames" {
+  description = "VPC DNS hostnames flag"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
- Close #4

## What happened 👀

Set up a Virtual Private Cloud (VPC) to manage and secure inbound and outbound traffic to our services and to divide up our assets into logical segments for better security and organization.

## Proof Of Work 📹

Plan was applied successfully (on test env):

![image](https://user-images.githubusercontent.com/475367/216248608-271d3d91-0b59-45da-8ca5-5647a222ffa1.png)

`terraform plan` output:

```
Terraform will perform the following actions:

  # module.vpc.module.vpc.aws_eip.nat[0] will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name" = "alex-ic-staging-vpc-ap-southeast-1a"
        }
      + tags_all             = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-ap-southeast-1a"
          + "Owner"       = "alex-ic"
        }
      + vpc                  = true
    }

  # module.vpc.module.vpc.aws_internet_gateway.this[0] will be created
  + resource "aws_internet_gateway" "this" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Name" = "alex-ic-staging-vpc"
        }
      + tags_all = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc"
          + "Owner"       = "alex-ic"
        }
      + vpc_id   = (known after apply)
    }

  # module.vpc.module.vpc.aws_nat_gateway.this[0] will be created
  + resource "aws_nat_gateway" "this" {
      + allocation_id        = (known after apply)
      + connectivity_type    = "public"
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Name" = "alex-ic-staging-vpc-ap-southeast-1a"
        }
      + tags_all             = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-ap-southeast-1a"
          + "Owner"       = "alex-ic"
        }
    }

  # module.vpc.module.vpc.aws_route.private_nat_gateway[0] will be created
  + resource "aws_route" "private_nat_gateway" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.module.vpc.aws_route.public_internet_gateway[0] will be created
  + resource "aws_route" "public_internet_gateway" {
      + destination_cidr_block = "0.0.0.0/0"
      + gateway_id             = (known after apply)
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.module.vpc.aws_route_table.private[0] will be created
  + resource "aws_route_table" "private" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "alex-ic-staging-vpc-private"
        }
      + tags_all         = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-private"
          + "Owner"       = "alex-ic"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table.public[0] will be created
  + resource "aws_route_table" "public" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "alex-ic-staging-vpc-public"
        }
      + tags_all         = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-public"
          + "Owner"       = "alex-ic"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.private[0] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.private[1] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.private[2] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.public[0] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.public[1] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_route_table_association.public[2] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.private[0] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-private-ap-southeast-1a"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-private-ap-southeast-1a"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.private[1] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-private-ap-southeast-1b"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-private-ap-southeast-1b"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.private[2] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.3.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-private-ap-southeast-1c"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-private-ap-southeast-1c"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.4.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-public-ap-southeast-1a"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-public-ap-southeast-1a"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.public[1] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.5.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-public-ap-southeast-1b"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-public-ap-southeast-1b"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_subnet.public[2] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-southeast-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.6.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "alex-ic-staging-vpc-public-ap-southeast-1c"
        }
      + tags_all                                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc-public-ap-southeast-1c"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.module.vpc.aws_vpc.this[0] will be created
  + resource "aws_vpc" "this" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = true
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "alex-ic-staging-vpc"
        }
      + tags_all                             = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-vpc"
          + "Owner"       = "alex-ic"
        }
    }

Plan: 20 to add, 0 to change, 0 to destroy.
```