### PR TITLE
[#5] [Infrastructure] Setup AWS CloudWatch Logs

### DIFF
--- a/base/.terraform.lock.hcl
+++ b/base/.terraform.lock.hcl
@@ -29,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.4.3"
   hashes = [
     "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
     "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
     "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",

--- a/base/main.tf
+++ b/base/main.tf
@@ -14,6 +14,13 @@ locals {
   namespace = "${var.app_name}-${var.environment}"
 }
 
+module "log" {
+  source = "../modules/cloudwatch"
+
+  namespace                     = local.namespace
+  secret_cloudwatch_log_key_arn = module.kms.secret_cloudwatch_log_key_arn
+}
+
 module "vpc" {
   source = "../modules/vpc"
 
@@ -24,6 +31,7 @@ module "kms" {
   source = "../modules/kms"
 
   namespace = local.namespace
+  region    = var.region
 
   secrets = {
     secret_key_base = var.secret_key_base

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "awslogs-${var.namespace}-log-group"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.secret_cloudwatch_log_key_arn
+}

--- a/modules/cloudwatch/outputs.tf
+++ b/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_cloudwatch_log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.main.name
+}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -1,0 +1,14 @@
+variable "namespace" {
+  description = "The namespace for the CloudWatch"
+  type        = string
+}
+
+variable "log_retention_in_days" {
+  description = "How long (days) to retain the log data"
+  default     = 14
+}
+
+variable "secret_cloudwatch_log_key_arn" {
+  description = "The key to use for logs encryption"
+  type        = string
+}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -7,3 +7,8 @@ output "secret_arns" {
   description = "The secrets ARNs for Task Definition"
   value       = local.secret_arns
 }
+
+output "secret_cloudwatch_log_key_arn" {
+  description = "The key to use for logs encryption"
+  value       = local.secret_cloudwatch_log_key_arn
+}

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -14,3 +14,8 @@ variable "deletion_window" {
   type        = number
   default     = 7
 }
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}


### PR DESCRIPTION
- Close #5

## What happened 👀

Setting up AWS CloudWatch Logs is an essential part of managing a system’s performance. This service provides you with the capability to monitor and analyze log data from various sources in the AWS Cloud, and to decode application logs for proactive monitoring and troubleshooting.

These Cloudwatch logs are encrypted with the KMS key.

## Proof Of Work 📹

Plan was applied successfully (on test env):

![image](https://user-images.githubusercontent.com/475367/216268029-d113824a-3dc3-426c-a876-90aaef0c2a71.png)

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.kms.aws_kms_key.log_key will be created
  + resource "aws_kms_key" "log_key" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + description                        = "KMS key for alex-ic-staging cloudwatch logs"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Id        = "key-default-1"
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::301618631622:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:Encrypt*",
                          + "kms:Decrypt*",
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Describe*",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "logs.ap-southeast-1.amazonaws.com"
                        }
                      + Resource  = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "Name" = "alex-ic-staging-kms-log-key"
        }
      + tags_all                           = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-kms-log-key"
          + "Owner"       = "alex-ic"
        }
    }

  # module.log.aws_cloudwatch_log_group.main will be created
  + resource "aws_cloudwatch_log_group" "main" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + kms_key_id        = (known after apply)
      + name              = "awslogs-alex-ic-staging-log-group"
      + name_prefix       = (known after apply)
      + retention_in_days = 14
      + skip_destroy      = false
      + tags_all          = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
