### PR TITLE
[#7] [#12] [Infrastructure] Setup AWS ALB [Infrastructure] Setup AWS S3

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -37,3 +37,28 @@ module "kms" {
     secret_key_base = var.secret_key_base
   }
 }
+
+module "security_group" {
+  source = "../modules/security_group"
+
+  namespace = local.namespace
+  vpc_id    = module.vpc.vpc_id
+  app_port  = var.app_port
+}
+
+module "s3" {
+  source = "../modules/s3"
+
+  namespace = local.namespace
+}
+
+module "alb" {
+  source = "../modules/alb"
+
+  vpc_id             = module.vpc.vpc_id
+  namespace          = local.namespace
+  app_port           = var.app_port
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = module.security_group.alb_security_group_ids
+  health_check_path  = var.health_check_path
+}

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -33,3 +33,13 @@ variable "secret_key_base" {
   description = "The Secret key base for the application"
   type        = string
 }
+
+variable "app_port" {
+  description = "Application running port"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "The health check path of the Application"
+  type        = string
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,0 +1,58 @@
+#tfsec:ignore:aws-elb-alb-not-public
+resource "aws_lb" "main" {
+  name               = "${var.namespace}-alb"
+  internal           = false
+  subnets            = var.subnet_ids
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+
+  enable_deletion_protection = false
+  drop_invalid_header_fields = true
+
+  access_logs {
+    bucket  = "${var.namespace}-alb-log"
+    enabled = true
+  }
+}
+
+resource "aws_lb_target_group" "target_group" {
+  name                 = "${var.namespace}-alb-tg-${substr(uuid(), 0, 3)}"
+  port                 = var.app_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
+  deregistration_delay = 100
+
+  health_check {
+    healthy_threshold   = 3
+    interval            = 5
+    protocol            = "HTTP"
+    matcher             = "200-299"
+    timeout             = 3
+    path                = var.health_check_path
+    port                = var.app_port
+    unhealthy_threshold = 2
+  }
+
+  stickiness {
+    enabled = true
+    type    = "lb_cookie"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [name]
+  }
+}
+
+#tfsec:ignore:aws-elb-http-not-used
+resource "aws_lb_listener" "app_http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group.arn
+  }
+}

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,0 +1,19 @@
+output "alb_name" {
+  description = "Application LB name"
+  value       = aws_lb.main.name
+}
+
+output "alb_dns_name" {
+  description = "Application LB DNS name"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Application LB Zone ID"
+  value       = aws_lb.main.zone_id
+}
+
+output "alb_target_group_arn" {
+  description = "ALB target group ARN"
+  value       = aws_lb_target_group.target_group.arn
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,0 +1,29 @@
+variable "namespace" {
+  description = "The namespace for the LB"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs to attach to the LB"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "A list of security group IDs to assign to the LB"
+  type        = list(string)
+}
+
+variable "health_check_path" {
+  description = "The health check path of the Application"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "app_port" {
+  description = "Application running port"
+  type        = number
+}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -9,6 +9,6 @@ output "secret_arns" {
 }
 
 output "secret_cloudwatch_log_key_arn" {
-  description = "The key to use for logs encryption"
+  description = "The key to use for cloudwatch logs encryption"
   value       = local.secret_cloudwatch_log_key_arn
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,0 +1,64 @@
+data "aws_elb_service_account" "elb_service_account" {}
+
+# tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-encryption
+resource "aws_s3_bucket" "alb_log" {
+  bucket        = "${var.namespace}-alb-log"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
+  bucket = aws_s3_bucket.alb_log.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_log" {
+  bucket                  = aws_s3_bucket.alb_log.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+locals {
+  aws_s3_bucket_policy = {
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            data.aws_elb_service_account.elb_service_account.arn
+          ]
+        }
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.alb_log.id}/AWSLogs/*"
+      },
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.alb_log.id}/AWSLogs/*",
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.alb_log.id}"
+      }
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_elb_logging" {
+  bucket = aws_s3_bucket.alb_log.id
+  policy = jsonencode(local.aws_s3_bucket_policy)
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_alb_log_bucket_name" {
+  description = "S3 bucket name for LB logging"
+  value       = aws_s3_bucket.alb_log.bucket
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,4 @@
+variable "namespace" {
+  description = "The namespace for the S3 buckets"
+  type        = string
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -1,0 +1,31 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.namespace}-alb-sg"
+  description = "ALB Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-alb-sg"
+  }
+}
+
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr
+resource "aws_security_group_rule" "alb_ingress_http" {
+  type              = "ingress"
+  security_group_id = aws_security_group.alb.id
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "From HTTP to ALB"
+}
+
+#tfsec:ignore:aws-ec2-no-public-egress-sgr
+resource "aws_security_group_rule" "alb_egress" {
+  type              = "egress"
+  security_group_id = aws_security_group.alb.id
+  protocol          = "tcp"
+  from_port         = var.app_port
+  to_port           = var.app_port
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "From ALB to app"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -1,0 +1,4 @@
+output "alb_security_group_ids" {
+  description = "Security group IDs for ALB"
+  value       = [aws_security_group.alb.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -1,0 +1,14 @@
+variable "namespace" {
+  description = "The namespace for the security groups, used as the prefix for the VPC security group names, e.g. acme-web-staging"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "app_port" {
+  description = "Application running port"
+  type        = number
+}


### PR DESCRIPTION
- Close #7 
- Close #12

## What happened 👀

Set up an Application Load Balancer (ALB) and an Amazon Simple Storage Service (S3) bucket for logging ALB activity. 

The S3 service can be leveraged in the future for storing application content files. 

Since ALB does not provide the capability to log to Amazon CloudWatch, an S3 bucket is required: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#access_logs

## Proof Of Work 📹

Plan was applied successfully (on test env):

![image](https://user-images.githubusercontent.com/475367/216736642-fc8f33b6-5be1-456d-be9b-46a5eb227517.png)

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.alb.aws_lb.main will be created
  + resource "aws_lb" "main" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + desync_mitigation_mode     = "defensive"
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = true
      + enable_deletion_protection = false
      + enable_http2               = true
      + enable_waf_fail_open       = false
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = (known after apply)
      + load_balancer_type         = "application"
      + name                       = "alex-ic-staging-alb"
      + preserve_host_header       = false
      + security_groups            = (known after apply)
      + subnets                    = [
          + "subnet-009c63829ea5098d6",
          + "subnet-032fa118f45ec3cef",
          + "subnet-09073722ed8d77b04",
        ]
      + tags_all                   = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + access_logs {
          + bucket  = "alex-ic-staging-alb-log"
          + enabled = true
        }

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # module.alb.aws_lb_listener.app_http will be created
  + resource "aws_lb_listener" "app_http" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 80
      + protocol          = "HTTP"
      + ssl_policy        = (known after apply)
      + tags_all          = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.alb.aws_lb_target_group.target_group will be created
  + resource "aws_lb_target_group" "target_group" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = false
      + deregistration_delay               = "100"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + port                               = 4000
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + target_type                        = "ip"
      + vpc_id                             = "vpc-031c6a72019833218"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 5
          + matcher             = "200-299"
          + path                = "/_health/readiness"
          + port                = "4000"
          + protocol            = "HTTP"
          + timeout             = 3
          + unhealthy_threshold = 2
        }

      + stickiness {
          + cookie_duration = 86400
          + enabled         = true
          + type            = "lb_cookie"
        }

      + target_failover {
          + on_deregistration = (known after apply)
          + on_unhealthy      = (known after apply)
        }
    }

  # module.s3.aws_s3_bucket.alb_log will be created
  + resource "aws_s3_bucket" "alb_log" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "alex-ic-staging-alb-log"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.s3.aws_s3_bucket_acl.alb_log_bucket_acl will be created
  + resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.s3.aws_s3_bucket_policy.allow_elb_logging will be created
  + resource "aws_s3_bucket_policy" "allow_elb_logging" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.s3.aws_s3_bucket_public_access_block.alb_log will be created
  + resource "aws_s3_bucket_public_access_block" "alb_log" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # module.security_group.aws_security_group.alb will be created
  + resource "aws_security_group" "alb" {
      + arn                    = (known after apply)
      + description            = "ALB Security Group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "alex-ic-staging-alb-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "alex-ic-staging-alb-sg"
        }
      + tags_all               = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-alb-sg"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                 = "vpc-031c6a72019833218"
    }

  # module.security_group.aws_security_group_rule.alb_egress will be created
  + resource "aws_security_group_rule" "alb_egress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "From ALB to app"
      + from_port                = 4000
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 4000
      + type                     = "egress"
    }

  # module.security_group.aws_security_group_rule.alb_ingress_http will be created
  + resource "aws_security_group_rule" "alb_ingress_http" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "From HTTP to ALB"
      + from_port                = 80
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

Plan: 10 to add, 0 to change, 0 to destroy.
```
