### PR TITLE
[#10] [Infrastructure] Setup AWS ECS Fargate

### DIFF
--- a/base/variables.tf
+++ b/base/variables.tf
@@ -43,3 +43,16 @@ variable "health_check_path" {
   description = "The health check path of the Application"
   type        = string
 }
+
+variable "ecs" {
+  description = "ECS input variables"
+  type = object({
+    web_container_cpu                  = number
+    web_container_memory               = number
+    task_desired_count                 = number
+    deployment_maximum_percent         = number
+    deployment_minimum_healthy_percent = number
+    max_capacity                       = number
+    max_cpu_threshold                  = number
+  })
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,0 +1,194 @@
+data "aws_ecr_repository" "repo" {
+  name = var.ecr_repo_name
+}
+
+data "aws_ecs_task_definition" "task" {
+  task_definition = aws_ecs_task_definition.main.family
+}
+
+locals {
+  ecr_tag = "${var.namespace}-app"
+
+  # Environment variables from other variables
+  environment_variables = toset([
+    { name = "AWS_REGION", value = var.region },
+    { name = "HEALTH_PATH", value = var.health_check_path },
+    { name = "PHX_HOST", value = var.app_host },
+    { name = "PORT", value = var.app_port },
+    { name = "DATABASE_URL", value = "" },
+  ])
+
+  container_vars = {
+    namespace                          = var.namespace
+    region                             = var.region
+    app_host                           = var.app_host
+    app_port                           = var.app_port
+    web_container_cpu                  = var.web_container_cpu
+    web_container_memory               = var.web_container_memory
+    deployment_maximum_percent         = var.deployment_maximum_percent
+    deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+    aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url
+    aws_ecr_tag                        = local.ecr_tag
+    aws_cloudwatch_log_group_name      = var.aws_cloudwatch_log_group_name
+
+    environment_variables = local.environment_variables
+    secrets_variables     = var.secrets_variables
+  }
+
+  container_definitions = templatefile("${path.module}/service.json.tftpl", local.container_vars)
+
+  ecs_task_execution_kms_policy = {
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ],
+        Resource = "*"
+      }
+    ]
+  }
+
+  ecs_task_execution_secrets_manager_policy = {
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = var.secret_arns
+      }
+    ]
+  }
+
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# Task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${var.namespace}-ecs-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_policy" "ecs_task_execution_kms" {
+  policy = jsonencode(local.ecs_task_execution_kms_policy)
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_kms_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_kms.arn
+}
+
+resource "aws_iam_policy" "ecs_task_execution_secrets_manager" {
+  policy = jsonencode(local.ecs_task_execution_secrets_manager_policy)
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_secrets_manager_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_secrets_manager.arn
+}
+
+# Task role
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${var.namespace}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.namespace}-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${var.namespace}-service"
+  cpu                      = var.web_container_cpu
+  memory                   = var.web_container_memory
+  network_mode             = "awsvpc"
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  container_definitions    = local.container_definitions
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "main" {
+  name                               = "${var.namespace}-ecs-service"
+  cluster                            = aws_ecs_cluster.main.id
+  launch_type                        = "FARGATE"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  desired_count                      = var.desired_count
+  task_definition                    = "${aws_ecs_task_definition.main.family}:${max(aws_ecs_task_definition.main.revision, data.aws_ecs_task_definition.task.revision)}"
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = var.security_groups
+  }
+
+  load_balancer {
+    target_group_arn = var.alb_target_group_arn
+    container_name   = var.namespace
+    container_port   = var.app_port
+  }
+}
+
+resource "aws_appautoscaling_target" "main" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.desired_count
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "main" {
+  name               = "${var.namespace}-autoscaling-policy"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value = var.max_cpu_threshold
+
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}

--- a/modules/ecs/service.json.tftpl
+++ b/modules/ecs/service.json.tftpl
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "${namespace}",
+    "image": "${aws_ecr_repository}:${aws_ecr_tag}",
+    "essential": true,
+    "memory": ${web_container_memory},
+    "cpu": ${web_container_cpu},
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port},
+        "protocol": "tcp"
+      }
+    ],
+    "environment": ${jsonencode(environment_variables)},
+    "secrets": ${jsonencode(secrets_variables)},
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 65536,
+        "hardLimit": 65536
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "${namespace}-service",
+        "awslogs-group": "${aws_cloudwatch_log_group_name}"
+      }
+    }
+  }
+]

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,0 +1,93 @@
+variable "namespace" {
+  description = "The namespace for the ECS"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "app_host" {
+  description = "Application host name"
+  type        = string
+}
+
+variable "app_port" {
+  description = "Application running port"
+  type        = number
+}
+
+variable "ecr_repo_name" {
+  description = "ECR repo name"
+  type        = string
+}
+
+variable "subnets" {
+  description = "Subnet where ECS placed"
+  type        = list(string)
+}
+
+variable "security_groups" {
+  description = "One or more VPC security groups associated with ECS cluster"
+  type        = list(string)
+}
+
+variable "alb_target_group_arn" {
+  description = "ALB target group ARN"
+}
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "web_container_cpu" {
+  description = "ECS web container CPU"
+  type        = number
+}
+
+variable "web_container_memory" {
+  description = "ECS web container memory"
+  type        = number
+}
+
+variable "secrets_variables" {
+  description = "List of [{name = \"\", valueFrom = \"\"}] pairs of secret variables"
+  type        = list(any)
+}
+
+variable "secret_arns" {
+  description = "The secrets ARNs for Task Definition"
+  type        = list(string)
+}
+
+variable "desired_count" {
+  description = "ECS task definition instance number"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "Application health check path"
+  type        = string
+}
+
+variable "aws_cloudwatch_log_group_name" {
+  description = "AWS CloudWatch Log Group name"
+  type        = string
+}
+
+variable "max_capacity" {
+  description = "ECS max number of instances to run"
+  type        = number
+}
+
+variable "max_cpu_threshold" {
+  description = "Threshold for CPU load where to start autoscaling"
+  type        = number
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -29,3 +29,44 @@ resource "aws_security_group_rule" "alb_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "From ALB to app"
 }
+
+resource "aws_security_group" "ecs_fargate" {
+  name        = "${var.namespace}-ecs-fargate-sg"
+  description = "ECS Fargate Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-ecs-fargate-sg"
+  }
+}
+
+resource "aws_security_group_rule" "ecs_fargate_ingress_alb" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_fargate.id
+  protocol                 = "tcp"
+  from_port                = var.app_port
+  to_port                  = var.app_port
+  source_security_group_id = aws_security_group.alb.id
+  description              = "From ALB to app"
+}
+
+resource "aws_security_group_rule" "ecs_fargate_ingress_private" {
+  type              = "ingress"
+  security_group_id = aws_security_group.ecs_fargate.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 65535
+  cidr_blocks       = var.private_subnets_cidr_blocks
+  description       = "From internal VPC to app"
+}
+
+#tfsec:ignore:aws-ec2-no-public-egress-sgr
+resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
+  type              = "egress"
+  security_group_id = aws_security_group.ecs_fargate.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "From app to everywhere"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -2,3 +2,8 @@ output "alb_security_group_ids" {
   description = "Security group IDs for ALB"
   value       = [aws_security_group.alb.id]
 }
+
+output "ecs_security_group_ids" {
+  description = "Security group IDs for ECS Fargate"
+  value       = [aws_security_group.ecs_fargate.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -12,3 +12,8 @@ variable "app_port" {
   description = "Application running port"
   type        = number
 }
+
+variable "private_subnets_cidr_blocks" {
+  description = "Private subnet CIDR blocks"
+  type        = list(string)
+}


### PR DESCRIPTION
- Close #10 

## What happened 👀

Set up AWS ECS Fargate module.

AWS Elastic Container Service (ECS) is a fully-managed container orchestration service that makes it easy to deploy, run, and scale containerized applications.

Containers were run with these settings:

```
{
  web_container_cpu = 256
  web_container_memory = 512
  task_desired_count = 3
  deployment_maximum_percent = 200
  deployment_minimum_healthy_percent = 50
  max_capacity = 6
  max_cpu_threshold = 60
}
```

## Proof Of Work 📹

Plan was applied successfully (on test env):

<img width="1142" alt="image" src="https://user-images.githubusercontent.com/475367/216810464-ae79ade5-abd4-417a-8485-9c56646afcd3.png">

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.ecs.data.aws_ecs_task_definition.task will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "task" {
      + arn             = (known after apply)
      + family          = (known after apply)
      + id              = (known after apply)
      + network_mode    = (known after apply)
      + revision        = (known after apply)
      + status          = (known after apply)
      + task_definition = "alex-ic-staging-service"
      + task_role_arn   = (known after apply)
    }

  # module.ecs.aws_appautoscaling_policy.main will be created
  + resource "aws_appautoscaling_policy" "main" {
      + alarm_arns         = (known after apply)
      + arn                = (known after apply)
      + id                 = (known after apply)
      + name               = "alex-ic-staging-autoscaling-policy"
      + policy_type        = "TargetTrackingScaling"
      + resource_id        = "service/alex-ic-staging-ecs-cluster/alex-ic-staging-ecs-service"
      + scalable_dimension = "ecs:service:DesiredCount"
      + service_namespace  = "ecs"

      + target_tracking_scaling_policy_configuration {
          + disable_scale_in   = false
          + scale_in_cooldown  = 300
          + scale_out_cooldown = 300
          + target_value       = 60

          + predefined_metric_specification {
              + predefined_metric_type = "ECSServiceAverageCPUUtilization"
            }
        }
    }

  # module.ecs.aws_appautoscaling_target.main will be created
  + resource "aws_appautoscaling_target" "main" {
      + id                 = (known after apply)
      + max_capacity       = 6
      + min_capacity       = 3
      + resource_id        = "service/alex-ic-staging-ecs-cluster/alex-ic-staging-ecs-service"
      + role_arn           = (known after apply)
      + scalable_dimension = "ecs:service:DesiredCount"
      + service_namespace  = "ecs"
    }

  # module.ecs.aws_ecs_cluster.main will be created
  + resource "aws_ecs_cluster" "main" {
      + arn                = (known after apply)
      + capacity_providers = (known after apply)
      + id                 = (known after apply)
      + name               = "alex-ic-staging-ecs-cluster"
      + tags_all           = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }

      + default_capacity_provider_strategy {
          + base              = (known after apply)
          + capacity_provider = (known after apply)
          + weight            = (known after apply)
        }

      + setting {
          + name  = "containerInsights"
          + value = "enabled"
        }
    }

  # module.ecs.aws_ecs_service.main will be created
  + resource "aws_ecs_service" "main" {
      + cluster                            = (known after apply)
      + deployment_maximum_percent         = 200
      + deployment_minimum_healthy_percent = 50
      + desired_count                      = 3
      + enable_ecs_managed_tags            = false
      + enable_execute_command             = false
      + iam_role                           = (known after apply)
      + id                                 = (known after apply)
      + launch_type                        = "FARGATE"
      + name                               = "alex-ic-staging-ecs-service"
      + platform_version                   = (known after apply)
      + scheduling_strategy                = "REPLICA"
      + tags_all                           = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + task_definition                    = (known after apply)
      + triggers                           = (known after apply)
      + wait_for_steady_state              = false

      + deployment_circuit_breaker {
          + enable   = true
          + rollback = true
        }

      + load_balancer {
          + container_name   = "alex-ic-staging"
          + container_port   = 4000
          + target_group_arn = "arn:aws:elasticloadbalancing:ap-southeast-1:301618631622:targetgroup/alex-ic-staging-alb-tg-eb3/cc7387738e1605c5"
        }

      + network_configuration {
          + assign_public_ip = false
          + security_groups  = (known after apply)
          + subnets          = [
              + "subnet-026ebe84c41313025",
              + "subnet-0841ee1975233c827",
              + "subnet-093edadc5b4b4258d",
            ]
        }
    }

  # module.ecs.aws_ecs_task_definition.main will be created
  + resource "aws_ecs_task_definition" "main" {
      + arn                      = (known after apply)
      + container_definitions    = jsonencode(
            [
              + {
                  + cpu              = 256
                  + environment      = [
                      + {
                          + name  = "AWS_REGION"
                          + value = "ap-southeast-1"
                        },
                      + {
                          + name  = "DATABASE_URL"
                          + value = ""
                        },
                      + {
                          + name  = "HEALTH_PATH"
                          + value = "/_health/readiness"
                        },
                      + {
                          + name  = "PHX_HOST"
                          + value = "alex-ic-staging-alb-2081645651.ap-southeast-1.elb.amazonaws.com"
                        },
                      + {
                          + name  = "PORT"
                          + value = "4000"
                        },
                    ]
                  + essential        = true
                  + image            = "301618631622.dkr.ecr.ap-southeast-1.amazonaws.com/alex-ic:alex-ic-staging-app"
                  + logConfiguration = {
                      + logDriver = "awslogs"
                      + options   = {
                          + awslogs-group         = "awslogs-alex-ic-staging-log-group"
                          + awslogs-region        = "ap-southeast-1"
                          + awslogs-stream-prefix = "alex-ic-staging-service"
                        }
                    }
                  + memory           = 512
                  + name             = "alex-ic-staging"
                  + portMappings     = [
                      + {
                          + containerPort = 4000
                          + hostPort      = 4000
                          + protocol      = "tcp"
                        },
                    ]
                  + secrets          = [
                      + {
                          + name      = "SECRET_KEY_BASE"
                          + valueFrom = "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-omaqNY-8NdiuY"
                        },
                    ]
                  + ulimits          = [
                      + {
                          + hardLimit = 65536
                          + name      = "nofile"
                          + softLimit = 65536
                        },
                    ]
                },
            ]
        )
      + cpu                      = "256"
      + execution_role_arn       = (known after apply)
      + family                   = "alex-ic-staging-service"
      + id                       = (known after apply)
      + memory                   = "512"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + skip_destroy             = false
      + tags_all                 = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + task_role_arn            = (known after apply)
    }

  # module.ecs.aws_iam_policy.ecs_task_execution_kms will be created
  + resource "aws_iam_policy" "ecs_task_execution_kms" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = (known after apply)
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "kms:Encrypt",
                          + "kms:Decrypt",
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:CreateGrant",
                          + "kms:DescribeKey",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
    }

  # module.ecs.aws_iam_policy.ecs_task_execution_secrets_manager will be created
  + resource "aws_iam_policy" "ecs_task_execution_secrets_manager" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = (known after apply)
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "secretsmanager:GetSecretValue",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-omaqNY-8NdiuY",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
    }

  # module.ecs.aws_iam_role.ecs_task_execution_role will be created
  + resource "aws_iam_role" "ecs_task_execution_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "alex-ic-staging-ecs-execution-role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.ecs.aws_iam_role.ecs_task_role will be created
  + resource "aws_iam_role" "ecs_task_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "alex-ic-staging-ecs-task-role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.ecs.aws_iam_role_policy_attachment.ecs_task_execution_kms_policy will be created
  + resource "aws_iam_role_policy_attachment" "ecs_task_execution_kms_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "alex-ic-staging-ecs-execution-role"
    }

  # module.ecs.aws_iam_role_policy_attachment.ecs_task_execution_role will be created
  + resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
      + role       = "alex-ic-staging-ecs-execution-role"
    }

  # module.ecs.aws_iam_role_policy_attachment.ecs_task_execution_secrets_manager_policy will be created
  + resource "aws_iam_role_policy_attachment" "ecs_task_execution_secrets_manager_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "alex-ic-staging-ecs-execution-role"
    }

  # module.security_group.aws_security_group.ecs_fargate will be created
  + resource "aws_security_group" "ecs_fargate" {
      + arn                    = (known after apply)
      + description            = "ECS Fargate Security Group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "alex-ic-staging-ecs-fargate-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "alex-ic-staging-ecs-fargate-sg"
        }
      + tags_all               = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-ecs-fargate-sg"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                 = "vpc-09793e3dfa416c8dd"
    }

  # module.security_group.aws_security_group_rule.ecs_fargate_egress_anywhere will be created
  + resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "From app to everywhere"
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # module.security_group.aws_security_group_rule.ecs_fargate_ingress_alb will be created
  + resource "aws_security_group_rule" "ecs_fargate_ingress_alb" {
      + description              = "From ALB to app"
      + from_port                = 4000
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-01e9168879aef6fbd"
      + to_port                  = 4000
      + type                     = "ingress"
    }

  # module.security_group.aws_security_group_rule.ecs_fargate_ingress_private will be created
  + resource "aws_security_group_rule" "ecs_fargate_ingress_private" {
      + cidr_blocks              = [
          + "10.0.1.0/24",
          + "10.0.2.0/24",
          + "10.0.3.0/24",
        ]
      + description              = "From internal VPC to app"
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "ingress"
    }

Plan: 16 to add, 0 to change, 0 to destroy.
```
