### PR TITLE
[#8] [Infrastructure] Setup AWS RDS

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -34,6 +34,7 @@ module "kms" {
   region    = var.region
 
   secrets = {
+    database_url    = module.rds.db_url
     secret_key_base = var.secret_key_base
   }
 }
@@ -45,6 +46,7 @@ module "security_group" {
   vpc_id                      = module.vpc.vpc_id
   app_port                    = var.app_port
   private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  rds_port                    = var.rds_port
 }
 
 module "s3" {
@@ -87,4 +89,23 @@ module "ecs" {
 
   secrets_variables = module.kms.secrets_variables
   secret_arns       = module.kms.secret_arns
+}
+
+module "rds" {
+  source = "../modules/rds"
+
+  namespace = local.namespace
+
+  vpc_security_group_ids = module.security_group.rds_security_group_ids
+  vpc_id                 = module.vpc.vpc_id
+  subnet_ids             = module.vpc.private_subnet_ids
+
+  instance_type = var.rds_instance_type
+  database_name = var.environment
+  username      = var.rds_username
+  password      = var.rds_password
+  port          = var.rds_port
+
+  autoscaling_min_capacity = var.rds_autoscaling_min_capacity
+  autoscaling_max_capacity = var.rds_autoscaling_max_capacity
 }

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -56,3 +56,31 @@ variable "ecs" {
     max_cpu_threshold                  = number
   })
 }
+
+variable "rds_instance_type" {
+  default = "db.t4g.medium"
+}
+
+variable "rds_username" {
+  description = "RDS username"
+  type        = string
+}
+
+variable "rds_password" {
+  description = "RDS password"
+  type        = string
+}
+
+variable "rds_port" {
+  default = 5432
+}
+
+variable "rds_autoscaling_min_capacity" {
+  description = "Minimum number of RDS read replicas when autoscaling is enabled"
+  default     = 1
+}
+
+variable "rds_autoscaling_max_capacity" {
+  description = "Maximum number of RDS read replicas when autoscaling is enabled"
+  default     = 5
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -15,7 +15,6 @@ locals {
     { name = "HEALTH_PATH", value = var.health_check_path },
     { name = "PHX_HOST", value = var.app_host },
     { name = "PORT", value = var.app_port },
-    { name = "DATABASE_URL", value = "" },
   ])
 
   container_vars = {

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,40 @@
+data "aws_availability_zones" "available" {}
+
+module "rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "7.6.0"
+
+  name = "${var.namespace}-aurora-db"
+
+  engine         = var.engine
+  engine_version = var.engine_version
+
+  availability_zones     = data.aws_availability_zones.available.names
+  vpc_id                 = var.vpc_id
+  subnets                = var.subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  instance_class = var.instance_type
+  instances = {
+    main = {}
+  }
+
+  autoscaling_enabled      = true
+  autoscaling_min_capacity = var.autoscaling_min_capacity
+  autoscaling_max_capacity = var.autoscaling_max_capacity
+
+  create_monitoring_role = var.create_monitoring_role
+  create_random_password = false
+  create_security_group  = false
+  storage_encrypted      = true
+
+  publicly_accessible = false
+
+  database_name       = var.database_name
+  master_username     = var.username
+  master_password     = var.password
+  port                = var.port
+  deletion_protection = false
+
+  enabled_cloudwatch_logs_exports = var.cloudwatch_logs_exports
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,11 @@
+locals {
+  db_url = "postgresql://${var.username}:${var.password}@${module.rds.cluster_endpoint}/${var.database_name}"
+}
+
+output "db_endpoint" {
+  value = module.rds.cluster_endpoint
+}
+
+output "db_url" {
+  value = local.db_url
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,78 @@
+variable "namespace" {
+  description = "The namespace for the DB"
+  type        = string
+}
+
+variable "engine" {
+  description = "The Aurora DB Engine"
+  type        = string
+  default     = "aurora-postgresql"
+}
+
+variable "engine_version" {
+  description = "The Aurora DB Engine version"
+  type        = string
+  default     = "13.7"
+}
+
+variable "instance_type" {
+  description = "The Aurora DB instance type"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of security group IDs to assign to the DB"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "database_name" {
+  description = "The DB name"
+  type        = string
+}
+
+variable "username" {
+  description = "The DB master username"
+  type        = string
+}
+
+variable "password" {
+  description = "The DB master password"
+  type        = string
+}
+
+variable "port" {
+  description = "The DB port"
+  type        = number
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs for DB subnet group"
+  type        = list(string)
+}
+
+variable "autoscaling_min_capacity" {
+  description = "Minimum number of read replicas when autoscaling is enabled"
+  default     = 1
+}
+
+variable "autoscaling_max_capacity" {
+  description = "Maximum number of read replicas when autoscaling is enabled"
+  default     = 3
+}
+
+variable "create_monitoring_role" {
+  description = "A flag whether to create the IAM role for monitoring"
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_logs_exports" {
+  description = "A list of log types to export to CloudWatch"
+  type        = list(string)
+  default     = ["postgresql"]
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -70,3 +70,23 @@ resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "From app to everywhere"
 }
+
+resource "aws_security_group" "rds" {
+  name        = "${var.namespace}-rds"
+  description = "RDS Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-rds-sg"
+  }
+}
+
+resource "aws_security_group_rule" "rds_ingress_app_fargate" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_fargate.id
+  description              = "From app to DB"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -7,3 +7,8 @@ output "ecs_security_group_ids" {
   description = "Security group IDs for ECS Fargate"
   value       = [aws_security_group.ecs_fargate.id]
 }
+
+output "rds_security_group_ids" {
+  description = "Security group IDs for Aurora"
+  value       = [aws_security_group.rds.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -17,3 +17,8 @@ variable "private_subnets_cidr_blocks" {
   description = "Private subnet CIDR blocks"
   type        = list(string)
 }
+
+variable "rds_port" {
+  description = "The DB port"
+  type        = number
+}


### PR DESCRIPTION
- Close #8 

## What happened 👀

RDS Aurora database was set up and DB URL was saved in secrets manager for app to use.

## Proof Of Work 📹

Plan was applied successfully (on test env):

![image](https://user-images.githubusercontent.com/475367/217135611-9310232f-9ab9-40fe-864c-b56098340956.png)

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.ecs.data.aws_ecs_task_definition.task will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "task" {
      + arn             = (known after apply)
      + family          = (known after apply)
      + id              = (known after apply)
      + network_mode    = (known after apply)
      + revision        = (known after apply)
      + status          = (known after apply)
      + task_definition = "alex-ic-staging-service"
      + task_role_arn   = (known after apply)
    }

  # module.ecs.aws_ecs_service.main will be updated in-place
  ~ resource "aws_ecs_service" "main" {
      ~ deployment_minimum_healthy_percent = 100 -> 50
        id                                 = "arn:aws:ecs:ap-southeast-1:301618631622:service/alex-ic-staging-ecs-cluster/alex-ic-staging-ecs-service"
        name                               = "alex-ic-staging-ecs-service"
        tags                               = {}
      ~ task_definition                    = "alex-ic-staging-service:34" -> (known after apply)
        # (14 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.ecs.aws_ecs_task_definition.main must be replaced
-/+ resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:ap-southeast-1:301618631622:task-definition/alex-ic-staging-service:34" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "AWS_REGION"
                          - value = "ap-southeast-1"
                        },
                      - {
                          - name  = "DATABASE_URL"
                          - value = ""
                        },
                      - {
                          - name  = "HEALTH_PATH"
                          - value = "/_health/readiness"
                        },
                      - {
                          - name  = "PHX_HOST"
                          - value = "alex-ic-staging-alb-879036711.ap-southeast-1.elb.amazonaws.com"
                        },
                      - {
                          - name  = "PORT"
                          - value = "4000"
                        },
                    ]
                  - essential        = true
                  - image            = "301618631622.dkr.ecr.ap-southeast-1.amazonaws.com/alex-ic:alex-ic-staging-app"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "awslogs-alex-ic-staging-log-group"
                          - awslogs-region        = "ap-southeast-1"
                          - awslogs-stream-prefix = "alex-ic-staging-service"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "alex-ic-staging"
                  - portMappings     = [
                      - {
                          - containerPort = 4000
                          - hostPort      = 4000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets          = [
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-UaItmE-U7Szz5"
                        },
                    ]
                  - ulimits          = [
                      - {
                          - hardLimit = 65536
                          - name      = "nofile"
                          - softLimit = 65536
                        },
                    ]
                  - volumesFrom      = []
                },
            ]
        ) -> (known after apply) # forces replacement
      ~ id                       = "alex-ic-staging-service" -> (known after apply)
      ~ revision                 = 34 -> (known after apply)
      - tags                     = {} -> null
        # (9 unchanged attributes hidden)
    }

  # module.ecs.aws_iam_policy.ecs_task_execution_secrets_manager will be updated in-place
  ~ resource "aws_iam_policy" "ecs_task_execution_secrets_manager" {
        id        = "arn:aws:iam::301618631622:policy/terraform-20230207014237061800000004"
        name      = "terraform-20230207014237061800000004"
      ~ policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-UaItmE-U7Szz5",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.kms.aws_secretsmanager_secret.service_secrets["database_url"] will be created
  + resource "aws_secretsmanager_secret" "service_secrets" {
      + arn                            = (known after apply)
      + description                    = "Secret 'secret_database_url' for alex-ic-staging"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + kms_key_id                     = "arn:aws:kms:ap-southeast-1:301618631622:key/b455bb64-d363-4f2d-9faf-43c74e537dac"
      + name                           = "alex-ic-staging/database_url-UaItmE"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 0
      + rotation_enabled               = (known after apply)
      + rotation_lambda_arn            = (known after apply)
      + tags                           = {
          + "Name" = "alex-ic-staging-kms"
        }
      + tags_all                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-kms"
          + "Owner"       = "alex-ic"
        }

      + replica {
          + kms_key_id         = (known after apply)
          + last_accessed_date = (known after apply)
          + region             = (known after apply)
          + status             = (known after apply)
          + status_message     = (known after apply)
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # module.kms.aws_secretsmanager_secret_version.service_secrets["database_url"] will be created
  + resource "aws_secretsmanager_secret_version" "service_secrets" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }

  # module.security_group.aws_security_group.rds will be created
  + resource "aws_security_group" "rds" {
      + arn                    = (known after apply)
      + description            = "RDS Security Group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "alex-ic-staging-rds"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "alex-ic-staging-rds-sg"
        }
      + tags_all               = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-rds-sg"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                 = "vpc-02eac000480e75fd9"
    }

  # module.security_group.aws_security_group_rule.rds_ingress_app_fargate will be created
  + resource "aws_security_group_rule" "rds_ingress_app_fargate" {
      + description              = "From app to DB"
      + from_port                = 5432
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-013324ac7d065b86a"
      + to_port                  = 5432
      + type                     = "ingress"
    }

  # module.rds.module.rds.aws_appautoscaling_policy.this[0] will be created
  + resource "aws_appautoscaling_policy" "this" {
      + alarm_arns         = (known after apply)
      + arn                = (known after apply)
      + id                 = (known after apply)
      + name               = "target-metric"
      + policy_type        = "TargetTrackingScaling"
      + resource_id        = "cluster:alex-ic-staging-aurora-db"
      + scalable_dimension = "rds:cluster:ReadReplicaCount"
      + service_namespace  = "rds"

      + target_tracking_scaling_policy_configuration {
          + disable_scale_in   = false
          + scale_in_cooldown  = 300
          + scale_out_cooldown = 300
          + target_value       = 70

          + predefined_metric_specification {
              + predefined_metric_type = "RDSReaderAverageCPUUtilization"
            }
        }
    }

  # module.rds.module.rds.aws_appautoscaling_target.this[0] will be created
  + resource "aws_appautoscaling_target" "this" {
      + id                 = (known after apply)
      + max_capacity       = 5
      + min_capacity       = 1
      + resource_id        = "cluster:alex-ic-staging-aurora-db"
      + role_arn           = (known after apply)
      + scalable_dimension = "rds:cluster:ReadReplicaCount"
      + service_namespace  = "rds"
    }

  # module.rds.module.rds.aws_db_subnet_group.this[0] will be created
  + resource "aws_db_subnet_group" "this" {
      + arn                     = (known after apply)
      + description             = "For Aurora cluster alex-ic-staging-aurora-db"
      + id                      = (known after apply)
      + name                    = "alex-ic-staging-aurora-db"
      + name_prefix             = (known after apply)
      + subnet_ids              = [
          + "subnet-024e4623f50f18a8b",
          + "subnet-097201cc1ea5b1b67",
          + "subnet-099e594922d5e215f",
        ]
      + supported_network_types = (known after apply)
      + tags_all                = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
    }

  # module.rds.module.rds.aws_rds_cluster.this[0] will be created
  + resource "aws_rds_cluster" "this" {
      + allocated_storage               = (known after apply)
      + allow_major_version_upgrade     = false
      + apply_immediately               = (known after apply)
      + arn                             = (known after apply)
      + availability_zones              = [
          + "ap-southeast-1a",
          + "ap-southeast-1b",
          + "ap-southeast-1c",
        ]
      + backtrack_window                = 0
      + backup_retention_period         = 7
      + cluster_identifier              = "alex-ic-staging-aurora-db"
      + cluster_identifier_prefix       = (known after apply)
      + cluster_members                 = (known after apply)
      + cluster_resource_id             = (known after apply)
      + copy_tags_to_snapshot           = false
      + database_name                   = "staging"
      + db_cluster_parameter_group_name = (known after apply)
      + db_subnet_group_name            = "alex-ic-staging-aurora-db"
      + deletion_protection             = false
      + enable_global_write_forwarding  = false
      + enable_http_endpoint            = false
      + enabled_cloudwatch_logs_exports = [
          + "postgresql",
        ]
      + endpoint                        = (known after apply)
      + engine                          = "aurora-postgresql"
      + engine_mode                     = "provisioned"
      + engine_version                  = "13.7"
      + engine_version_actual           = (known after apply)
      + final_snapshot_identifier       = (known after apply)
      + hosted_zone_id                  = (known after apply)
      + iam_roles                       = (known after apply)
      + id                              = (known after apply)
      + kms_key_id                      = (known after apply)
      + master_password                 = (sensitive value)
      + master_username                 = (sensitive value)
      + network_type                    = (known after apply)
      + port                            = 5432
      + preferred_backup_window         = "02:00-03:00"
      + preferred_maintenance_window    = "sun:05:00-sun:06:00"
      + reader_endpoint                 = (known after apply)
      + skip_final_snapshot             = false
      + storage_encrypted               = true
      + tags_all                        = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + vpc_security_group_ids          = (known after apply)

      + timeouts {}
    }

  # module.rds.module.rds.aws_rds_cluster_instance.this["main"] will be created
  + resource "aws_rds_cluster_instance" "this" {
      + apply_immediately                     = (known after apply)
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + ca_cert_identifier                    = (known after apply)
      + cluster_identifier                    = (known after apply)
      + copy_tags_to_snapshot                 = false
      + db_parameter_group_name               = (known after apply)
      + db_subnet_group_name                  = "alex-ic-staging-aurora-db"
      + dbi_resource_id                       = (known after apply)
      + endpoint                              = (known after apply)
      + engine                                = "aurora-postgresql"
      + engine_version                        = "13.7"
      + engine_version_actual                 = (known after apply)
      + id                                    = (known after apply)
      + identifier                            = "alex-ic-staging-aurora-db-main"
      + identifier_prefix                     = (known after apply)
      + instance_class                        = "db.t4g.medium"
      + kms_key_id                            = (known after apply)
      + monitoring_interval                   = 0
      + monitoring_role_arn                   = (known after apply)
      + network_type                          = (known after apply)
      + performance_insights_enabled          = (known after apply)
      + performance_insights_kms_key_id       = (known after apply)
      + performance_insights_retention_period = (known after apply)
      + port                                  = (known after apply)
      + preferred_backup_window               = (known after apply)
      + preferred_maintenance_window          = "sun:05:00-sun:06:00"
      + promotion_tier                        = 0
      + publicly_accessible                   = false
      + storage_encrypted                     = (known after apply)
      + tags_all                              = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + writer                                = (known after apply)

      + timeouts {}
    }

  # module.rds.module.rds.random_id.snapshot_identifier[0] will be created
  + resource "random_id" "snapshot_identifier" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 4
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "id" = "alex-ic-staging-aurora-db"
        }
    }

Plan: 11 to add, 2 to change, 1 to destroy.
```
