### PR TITLE
[#9] [Infrastructure] Setup AWS ElastiCache

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -35,6 +35,7 @@ module "kms" {
 
   secrets = {
     database_url    = module.rds.db_url
+    redis_url       = module.elasticache.redis_primary_endpoint
     secret_key_base = var.secret_key_base
   }
 }
@@ -47,6 +48,7 @@ module "security_group" {
   app_port                    = var.app_port
   private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
   rds_port                    = var.rds_port
+  elasticache_port            = var.elasticache_port
 }
 
 module "s3" {
@@ -108,4 +110,14 @@ module "rds" {
 
   autoscaling_min_capacity = var.rds_autoscaling_min_capacity
   autoscaling_max_capacity = var.rds_autoscaling_max_capacity
+}
+
+module "elasticache" {
+  source = "../modules/elasticache"
+
+  namespace = local.namespace
+
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = module.security_group.elasticache_security_group_ids
+  port               = var.elasticache_port
 }

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -84,3 +84,8 @@ variable "rds_autoscaling_max_capacity" {
   description = "Maximum number of RDS read replicas when autoscaling is enabled"
   default     = 5
 }
+
+variable "elasticache_port" {
+  description = "Elasticache port"
+  default     = 6379
+}

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -1,0 +1,23 @@
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.namespace}-subnet-group"
+  subnet_ids = var.subnet_ids
+}
+
+# tfsec:ignore:aws-elasticache-enable-in-transit-encryption tfsec:ignore:aws-elasticache-enable-at-rest-encryption
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.namespace}-rep-group"
+  description          = "${var.namespace} rep-group"
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = var.security_group_ids
+
+  engine         = var.engine
+  node_type      = var.node_type
+  port           = var.port
+  engine_version = var.engine_version
+
+  parameter_group_name       = var.parameter_group_name
+  automatic_failover_enabled = var.automatic_failover_enabled
+  num_cache_clusters         = var.number_cache_clusters
+  at_rest_encryption_enabled = false
+}

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,0 +1,4 @@
+output "redis_primary_endpoint" {
+  description = "Redis primary endpoint"
+  value       = "redis://${aws_elasticache_replication_group.main.primary_endpoint_address}:${var.port}"
+}

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -1,0 +1,49 @@
+variable "namespace" {
+  description = "The namespace for the ECR"
+  type        = string
+}
+
+variable "engine" {
+  description = "Cluster engine"
+  default     = "redis"
+}
+
+variable "engine_version" {
+  description = "Engine version"
+  default     = "6.x"
+}
+
+variable "parameter_group_name" {
+  description = "Parameter group for the cache cluster"
+  default     = "default.redis6.x"
+}
+
+variable "node_type" {
+  description = "Node type"
+  default     = "cache.t3.small"
+}
+
+variable "port" {
+  description = "Cache node port"
+  type        = number
+}
+
+variable "automatic_failover_enabled" {
+  description = "Whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails"
+  default     = false
+}
+
+variable "number_cache_clusters" {
+  description = "Number of cache clusters"
+  default     = 1
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs"
+  type        = list(any)
+}
+
+variable "security_group_ids" {
+  description = "One or more VPC security groups associated with the cache cluster"
+  type        = list(any)
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -90,3 +90,23 @@ resource "aws_security_group_rule" "rds_ingress_app_fargate" {
   source_security_group_id = aws_security_group.ecs_fargate.id
   description              = "From app to DB"
 }
+
+resource "aws_security_group" "elasticache" {
+  name        = "${var.namespace}-elasticache"
+  description = "Elasticache Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-elasticache-sg"
+  }
+}
+
+resource "aws_security_group_rule" "elasticache_ingress_app_fargate" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.elasticache.id
+  from_port                = var.elasticache_port
+  to_port                  = var.elasticache_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_fargate.id
+  description              = "From app to cache"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -12,3 +12,8 @@ output "rds_security_group_ids" {
   description = "Security group IDs for Aurora"
   value       = [aws_security_group.rds.id]
 }
+
+output "elasticache_security_group_ids" {
+  description = "Security group IDs for Elasticache"
+  value       = [aws_security_group.elasticache.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -22,3 +22,8 @@ variable "rds_port" {
   description = "The DB port"
   type        = number
 }
+
+variable "elasticache_port" {
+  description = "The cache node port"
+  type        = number
+}


### PR DESCRIPTION
- Close #9

## What happened 👀

AWS ElastiCache is a fully-managed in-memory caching service that simplifies the setup, operation and scaling of an in-memory cache in the cloud. 

In PR, we have set up a single node configuration without multi-AZ support, since the Elixir library is not yet capable of using ElastiCache clusters.

## Proof Of Work 📹

Plan was applied successfully (on test env):

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/475367/217724079-6b28a8f5-924f-4866-8552-f3612e3601ab.png">

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.ecs.data.aws_ecs_task_definition.task will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "task" {
      + arn             = (known after apply)
      + family          = (known after apply)
      + id              = (known after apply)
      + network_mode    = (known after apply)
      + revision        = (known after apply)
      + status          = (known after apply)
      + task_definition = "alex-ic-staging-service"
      + task_role_arn   = (known after apply)
    }

  # module.ecs.aws_ecs_service.main will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:ap-southeast-1:301618631622:service/alex-ic-staging-ecs-cluster/alex-ic-staging-ecs-service"
        name                               = "alex-ic-staging-ecs-service"
        tags                               = {}
      ~ task_definition                    = "alex-ic-staging-service:48" -> (known after apply)
        # (15 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.ecs.aws_ecs_task_definition.main must be replaced
-/+ resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:ap-southeast-1:301618631622:task-definition/alex-ic-staging-service:48" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "AWS_REGION"
                          - value = "ap-southeast-1"
                        },
                      - {
                          - name  = "HEALTH_PATH"
                          - value = "/_health/readiness"
                        },
                      - {
                          - name  = "PHX_HOST"
                          - value = "alex-ic-staging-alb-1696736423.ap-southeast-1.elb.amazonaws.com"
                        },
                      - {
                          - name  = "PORT"
                          - value = "4000"
                        },
                    ]
                  - essential        = true
                  - image            = "301618631622.dkr.ecr.ap-southeast-1.amazonaws.com/alex-ic:alex-ic-staging-app"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "awslogs-alex-ic-staging-log-group"
                          - awslogs-region        = "ap-southeast-1"
                          - awslogs-stream-prefix = "alex-ic-staging-service"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "alex-ic-staging"
                  - portMappings     = [
                      - {
                          - containerPort = 4000
                          - hostPort      = 4000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets          = [
                      - {
                          - name      = "DATABASE_URL"
                          - valueFrom = "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/database_url-rU6tiA-jQm9UU"
                        },
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-rU6tiA-saNBxz"
                        },
                    ]
                  - ulimits          = [
                      - {
                          - hardLimit = 65536
                          - name      = "nofile"
                          - softLimit = 65536
                        },
                    ]
                  - volumesFrom      = []
                },
            ]
        ) -> (known after apply) # forces replacement
      ~ id                       = "alex-ic-staging-service" -> (known after apply)
      ~ revision                 = 48 -> (known after apply)
      - tags                     = {} -> null
        # (9 unchanged attributes hidden)
    }

  # module.ecs.aws_iam_policy.ecs_task_execution_secrets_manager will be updated in-place
  ~ resource "aws_iam_policy" "ecs_task_execution_secrets_manager" {
        id        = "arn:aws:iam::301618631622:policy/terraform-20230209023037316300000005"
        name      = "terraform-20230209023037316300000005"
      ~ policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/database_url-rU6tiA-jQm9UU",
                          - "arn:aws:secretsmanager:ap-southeast-1:301618631622:secret:alex-ic-staging/secret_key_base-rU6tiA-saNBxz",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.elasticache.aws_elasticache_replication_group.main will be created
  + resource "aws_elasticache_replication_group" "main" {
      + apply_immediately              = (known after apply)
      + arn                            = (known after apply)
      + at_rest_encryption_enabled     = false
      + auto_minor_version_upgrade     = (known after apply)
      + automatic_failover_enabled     = false
      + cluster_enabled                = (known after apply)
      + configuration_endpoint_address = (known after apply)
      + data_tiering_enabled           = (known after apply)
      + description                    = "alex-ic-staging rep-group"
      + engine                         = "redis"
      + engine_version                 = "6.x"
      + engine_version_actual          = (known after apply)
      + global_replication_group_id    = (known after apply)
      + id                             = (known after apply)
      + maintenance_window             = (known after apply)
      + member_clusters                = (known after apply)
      + multi_az_enabled               = false
      + node_type                      = "cache.t3.small"
      + num_cache_clusters             = 1
      + num_node_groups                = (known after apply)
      + number_cache_clusters          = (known after apply)
      + parameter_group_name           = "default.redis6.x"
      + port                           = 6379
      + primary_endpoint_address       = (known after apply)
      + reader_endpoint_address        = (known after apply)
      + replicas_per_node_group        = (known after apply)
      + replication_group_description  = (known after apply)
      + replication_group_id           = "alex-ic-staging-rep-group"
      + security_group_ids             = (known after apply)
      + security_group_names           = (known after apply)
      + snapshot_window                = (known after apply)
      + subnet_group_name              = "alex-ic-staging-subnet-group"
      + tags_all                       = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
      + transit_encryption_enabled     = (known after apply)

      + cluster_mode {
          + num_node_groups         = (known after apply)
          + replicas_per_node_group = (known after apply)
        }
    }

  # module.elasticache.aws_elasticache_subnet_group.main will be created
  + resource "aws_elasticache_subnet_group" "main" {
      + arn         = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "alex-ic-staging-subnet-group"
      + subnet_ids  = [
          + "subnet-0369c00f485c46b58",
          + "subnet-03a384832a42204dd",
          + "subnet-0629c8f0a821884fb",
        ]
      + tags_all    = {
          + "Environment" = "staging"
          + "Owner"       = "alex-ic"
        }
    }

  # module.kms.aws_secretsmanager_secret.service_secrets["redis_url"] will be created
  + resource "aws_secretsmanager_secret" "service_secrets" {
      + arn                            = (known after apply)
      + description                    = "Secret 'secret_redis_url' for alex-ic-staging"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + kms_key_id                     = "arn:aws:kms:ap-southeast-1:301618631622:key/56ec681e-4edc-4a70-9fa6-21c39905cb2f"
      + name                           = "alex-ic-staging/redis_url-rU6tiA"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 0
      + rotation_enabled               = (known after apply)
      + rotation_lambda_arn            = (known after apply)
      + tags                           = {
          + "Name" = "alex-ic-staging-kms"
        }
      + tags_all                       = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-kms"
          + "Owner"       = "alex-ic"
        }

      + replica {
          + kms_key_id         = (known after apply)
          + last_accessed_date = (known after apply)
          + region             = (known after apply)
          + status             = (known after apply)
          + status_message     = (known after apply)
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # module.kms.aws_secretsmanager_secret_version.service_secrets["redis_url"] will be created
  + resource "aws_secretsmanager_secret_version" "service_secrets" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }

  # module.security_group.aws_security_group.elasticache will be created
  + resource "aws_security_group" "elasticache" {
      + arn                    = (known after apply)
      + description            = "Elasticache Security Group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "alex-ic-staging-elasticache"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "alex-ic-staging-elasticache-sg"
        }
      + tags_all               = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-elasticache-sg"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                 = "vpc-0a9a607a089fc074a"
    }

  # module.security_group.aws_security_group_rule.elasticache_ingress_app_fargate will be created
  + resource "aws_security_group_rule" "elasticache_ingress_app_fargate" {
      + description              = "From app to cache"
      + from_port                = 6379
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-003a9ae52e9a10d08"
      + to_port                  = 6379
      + type                     = "ingress"
    }

Plan: 7 to add, 2 to change, 1 to destroy.
```