### PR TITLE
[#13] [Infrastructure] Setup EC2 server as Bastion

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -43,12 +43,13 @@ module "kms" {
 module "security_group" {
   source = "../modules/security_group"
 
-  namespace                   = local.namespace
-  vpc_id                      = module.vpc.vpc_id
-  app_port                    = var.app_port
-  private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
-  rds_port                    = var.rds_port
-  elasticache_port            = var.elasticache_port
+  namespace                     = local.namespace
+  vpc_id                        = module.vpc.vpc_id
+  app_port                      = var.app_port
+  private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
+  rds_port                      = var.rds_port
+  elasticache_port              = var.elasticache_port
+  bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
 }
 
 module "s3" {
@@ -120,4 +121,13 @@ module "elasticache" {
   subnet_ids         = module.vpc.private_subnet_ids
   security_group_ids = module.security_group.elasticache_security_group_ids
   port               = var.elasticache_port
+}
+
+module "bastion" {
+  source = "../modules/bastion"
+
+  namespace = local.namespace
+
+  subnet_ids                  = module.vpc.public_subnet_ids
+  instance_security_group_ids = module.security_group.bastion_security_group_ids
 }

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -89,3 +89,8 @@ variable "elasticache_port" {
   description = "Elasticache port"
   default     = 6379
 }
+
+variable "bastion_allowed_ip_connection" {
+  description = "IP that can be connected to Bastion instance"
+  type        = string
+}

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -1,0 +1,36 @@
+# tfsec:ignore:aws-ec2-no-public-ip
+resource "aws_launch_configuration" "bastion_instance" {
+  name_prefix                 = "${var.namespace}-bastion"
+  image_id                    = var.image_id
+  instance_type               = var.instance_type
+  key_name                    = "${var.namespace}-bastion"
+  security_groups             = var.instance_security_group_ids
+  associate_public_ip_address = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
+  }
+}
+
+resource "aws_autoscaling_group" "bastion_instance" {
+  name                 = "${var.namespace}-bastion"
+  launch_configuration = aws_launch_configuration.bastion_instance.name
+  min_size             = var.min_instance_count
+  max_size             = var.max_instance_count
+  desired_capacity     = var.instance_desired_count
+  vpc_zone_identifier  = var.subnet_ids
+
+  tag {
+    key                 = "Name"
+    value               = "${var.namespace}-bastion"
+    propagate_at_launch = true
+  }
+}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,39 @@
+variable "namespace" {
+  description = "The namespace for the bastion instance"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "The public subnet IDs for the instance"
+  type        = list(string)
+}
+
+variable "instance_security_group_ids" {
+  description = "The security group IDs for the instance"
+  type        = list(string)
+}
+
+variable "image_id" {
+  description = "The AMI image ID"
+  default     = "ami-0801a1e12f4a9ccc0"
+}
+
+variable "instance_type" {
+  description = "The instance type"
+  default     = "t3.nano"
+}
+
+variable "instance_desired_count" {
+  description = "The desired number of the instance"
+  default     = 1
+}
+
+variable "max_instance_count" {
+  description = "The maximum number of the instance"
+  default     = 1
+}
+
+variable "min_instance_count" {
+  description = "The minimum number of the instance"
+  default     = 1
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -110,3 +110,63 @@ resource "aws_security_group_rule" "elasticache_ingress_app_fargate" {
   source_security_group_id = aws_security_group.ecs_fargate.id
   description              = "From app to cache"
 }
+
+resource "aws_security_group" "bastion" {
+  name        = "${var.namespace}-bastion"
+  description = "Bastion Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-bastion-sg"
+  }
+}
+
+resource "aws_security_group_rule" "bastion_ingress_ssh" {
+  type              = "ingress"
+  security_group_id = aws_security_group.bastion.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.bastion_allowed_ip_connection}/32"]
+  description       = "Allowed IP connection"
+}
+
+resource "aws_security_group_rule" "elasticache_ingress_bastion" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.elasticache.id
+  from_port                = var.elasticache_port
+  to_port                  = var.elasticache_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "From bastion to ElastiCache"
+}
+
+resource "aws_security_group_rule" "bastion_egress_elasticache" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.bastion.id
+  from_port                = var.elasticache_port
+  to_port                  = var.elasticache_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.elasticache.id
+  description              = "From ElastiCache to bastion"
+}
+
+resource "aws_security_group_rule" "rds_ingress_bastion" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "From bastion to RDS"
+}
+
+resource "aws_security_group_rule" "bastion_egress_rds" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.bastion.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds.id
+  description              = "From RDS to bastion"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -17,3 +17,8 @@ output "elasticache_security_group_ids" {
   description = "Security group IDs for Elasticache"
   value       = [aws_security_group.elasticache.id]
 }
+
+output "bastion_security_group_ids" {
+  description = "Security group IDs for Bastion"
+  value       = [aws_security_group.bastion.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -27,3 +27,8 @@ variable "elasticache_port" {
   description = "The cache node port"
   type        = number
 }
+
+variable "bastion_allowed_ip_connection" {
+  description = "IP that can be connected to Bastion instance"
+  type        = string
+}


### PR DESCRIPTION
- Close #13

## What happened 👀

Set up a Bastion server which can subsequently be used as an SSH tunnel for connecting to our RDS and ElastiCache services.

## Proof Of Work 📹

Plan was applied successfully (on test env):

![image](https://user-images.githubusercontent.com/475367/217764422-7645bd11-9635-4341-963a-7631910fadb4.png)

SSH connection to created server is working:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/475367/217764684-6290091e-b8af-47be-be83-72bf18430b9f.png">

`$ terraform plan` (command output below, it executed planning on TF cloud)

```
Terraform will perform the following actions:

  # module.bastion.aws_autoscaling_group.bastion_instance will be created
  + resource "aws_autoscaling_group" "bastion_instance" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = (known after apply)
      + desired_capacity          = 1
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = (known after apply)
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_size                  = 1
      + metrics_granularity       = "1Minute"
      + min_size                  = 1
      + name                      = "alex-ic-staging-bastion"
      + name_prefix               = (known after apply)
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + vpc_zone_identifier       = [
          + "subnet-0055b51c53599e339",
          + "subnet-00bf8e2aac7d9dd2d",
          + "subnet-0b3114fe100c041c5",
        ]
      + wait_for_capacity_timeout = "10m"

      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "alex-ic-staging-bastion"
        }
    }

  # module.bastion.aws_launch_configuration.bastion_instance will be created
  + resource "aws_launch_configuration" "bastion_instance" {
      + arn                         = (known after apply)
      + associate_public_ip_address = true
      + ebs_optimized               = (known after apply)
      + enable_monitoring           = true
      + id                          = (known after apply)
      + image_id                    = "ami-0801a1e12f4a9ccc0"
      + instance_type               = "t3.nano"
      + key_name                    = "alex-ic-staging-bastion"
      + name                        = (known after apply)
      + name_prefix                 = "alex-ic-staging-bastion"
      + security_groups             = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + no_device             = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = "required"
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = true
          + iops                  = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # module.security_group.aws_security_group.bastion will be created
  + resource "aws_security_group" "bastion" {
      + arn                    = (known after apply)
      + description            = "Bastion Security Group"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "alex-ic-staging-bastion"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "alex-ic-staging-bastion-sg"
        }
      + tags_all               = {
          + "Environment" = "staging"
          + "Name"        = "alex-ic-staging-bastion-sg"
          + "Owner"       = "alex-ic"
        }
      + vpc_id                 = "vpc-0a9a607a089fc074a"
    }

  # module.security_group.aws_security_group_rule.bastion_egress_elasticache will be created
  + resource "aws_security_group_rule" "bastion_egress_elasticache" {
      + description              = "From ElastiCache to bastion"
      + from_port                = 6379
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0e0a510eb6a68b06c"
      + to_port                  = 6379
      + type                     = "egress"
    }

  # module.security_group.aws_security_group_rule.bastion_egress_rds will be created
  + resource "aws_security_group_rule" "bastion_egress_rds" {
      + description              = "From RDS to bastion"
      + from_port                = 5432
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0da4a4459ea002660"
      + to_port                  = 5432
      + type                     = "egress"
    }

  # module.security_group.aws_security_group_rule.bastion_ingress_ssh will be created
  + resource "aws_security_group_rule" "bastion_ingress_ssh" {
      + cidr_blocks              = [
          + "119.46.57.98/32",
        ]
      + description              = "Allowed IP connection"
      + from_port                = 22
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 22
      + type                     = "ingress"
    }

  # module.security_group.aws_security_group_rule.elasticache_ingress_bastion will be created
  + resource "aws_security_group_rule" "elasticache_ingress_bastion" {
      + description              = "From bastion to ElastiCache"
      + from_port                = 6379
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-0e0a510eb6a68b06c"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 6379
      + type                     = "ingress"
    }

  # module.security_group.aws_security_group_rule.rds_ingress_bastion will be created
  + resource "aws_security_group_rule" "rds_ingress_bastion" {
      + description              = "From bastion to RDS"
      + from_port                = 5432
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-0da4a4459ea002660"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 5432
      + type                     = "ingress"
    }

Plan: 8 to add, 0 to change, 0 to destroy.
```